### PR TITLE
Updates disparity dep to version with updated diff dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "acorn": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
@@ -511,23 +516,40 @@
       "dev": true
     },
     "disparity": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
-      "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+      "integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
       "requires": {
-        "ansi-styles": "^2.0.1",
-        "diff": "^1.3.2"
+        "ansi-styles": "^4.1.0",
+        "diff": "^4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "diff": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^1.18.2"
   },
   "dependencies": {
-    "disparity": "^2.0.0",
+    "disparity": "^3.0.0",
     "package-json-validator": "^0.6.3",
     "requireindex": "^1.2.0"
   },


### PR DESCRIPTION
Before v3 `disparity` had a dependency on an insecure version of `diff`. You can see that detailed in the `magento-eslint` [security alert](https://github.com/magento-research/magento-eslint/network/alert/package-lock.json/diff/open).

This bumps the version of `disparity` to one that has a fixed version of diff.

Note: Because `mocha` used a fixed version of diff, there was no alert for this repo.