### PR TITLE
Add local-dependency rule 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,8 @@ module.exports.configs = {
         rules: {
             'package-json/sort-collections': 'error',
             'package-json/order-properties': 'warn',
-            'package-json/valid-package-def': 'error'
+            'package-json/valid-package-def': 'error',
+            'package-json/local-dependency': 'error'
         }
     }
 };

--- a/lib/rules/local-dependency.js
+++ b/lib/rules/local-dependency.js
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Checks existence of local dependencies in the package.json
+ * @author Kendall Gassner
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const {
+    isPackageJson,
+    extractPackageObjectFromAST
+} = require('../processors/PackageJsonProcessor');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function fileExistsWithCaseSync(filepath) {
+    var dir = path.dirname(filepath);
+
+    if (dir === path.dirname(dir)) {
+        return true;
+    }
+    var filenames = fs.readdirSync(dir);
+    if (filenames.indexOf(path.basename(filepath)) === -1) {
+        return false;
+    }
+    return fileExistsWithCaseSync(dir);
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                'Checks existence of local dependencies in the package.json',
+            category: 'Best Practices',
+            recommended: true
+        },
+        fixable: null // or "code" or "whitespace"
+    },
+
+    create: function(context) {
+        return {
+            'Program:exit': node => {
+                if (!isPackageJson(context.getFilename())) {
+                    return;
+                }
+                const sourceCode = context.getSourceCode();
+                const packageRoot = extractPackageObjectFromAST(node);
+                const original = JSON.parse(sourceCode.getText(packageRoot));
+                const {
+                    dependencies,
+                    peerDependencies,
+                    devDependencies
+                } = original;
+
+                const depObjs = [
+                    Object.entries(dependencies || {}),
+                    Object.entries(peerDependencies || {}),
+                    Object.entries(devDependencies || {})
+                ];
+                depObjs.map(obj =>
+                    obj.map(([key, value]) => {
+                        if (value.includes('link:')) {
+                            const filePath = path.join(
+                                context
+                                    .getFilename()
+                                    .replace(/package\.json/g, '/'),
+                                value.replace(/link:/g, ''),
+                                '/package.json'
+                            );
+
+                            try {
+                                if (!fileExistsWithCaseSync(filePath)) {
+                                    context.report({
+                                        node: packageRoot,
+                                        message: `The package ${key} does not exist given the specified path: ${value}.`
+                                    });
+                                }
+                            } catch (e) {
+                                context.report({
+                                    node: packageRoot,
+                                    message: `The package ${key} does not exist given the specified path: ${value}.`
+                                });
+                            }
+                        }
+                    })
+                );
+            }
+        };
+    }
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "nyc --reporter=lcov --reporter=text mocha tests --recursive",
     "test:debug": "mocha --inspect-brk tests --recursive",
     "test:watch": "mocha tests --recursive --watch",
+    "lint": "yarn run eslint --ext .json,.js . ",
     "pretest": "npm run format",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{js,css,md}\" && eslint ./**/*.js"
   },

--- a/tests/lib/__fixtures__/local-dependency/package.json
+++ b/tests/lib/__fixtures__/local-dependency/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "eslint-plugin-package-json",
+    "version": "0.1.3",
+    "description": "Rules for valid, consistent, and readable package.json files",
+    "keywords": [
+      "eslint",
+      "eslintplugin",
+      "eslint-plugin",
+      "magento"
+    ],
+    "author": "Magento Commerce",
+    "license": "(OSL-3.0 OR AFL-3.0)",
+    "main": "lib/index.js",
+    "homepage": "https://github.com/zetlen/eslint-plugin-package-json#readme",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/zetlen/eslint-plugin-package-json/issues"
+    },
+    "bugs": {
+      "url": "https://github.com/zetlen/eslint-plugin-package-json/issues"
+    },
+    "scripts": {
+      "test": "nyc --reporter=lcov --reporter=text mocha 'tests/lib/rules/local-dependency.js' --recursive",
+      "test:debug": "mocha --inspect-brk tests --recursive",
+      "test:watch": "mocha tests --recursive --watch",
+      "pretest": "npm run format",
+      "format": "prettier --ignore-path .gitignore --write \"**/*.{js,css,md}\" && eslint ./**/*.js"
+    },
+    "devDependencies": {
+      "eslint": "^5.8.0",
+      "lodash": "^4.17.15",
+      "mocha": "^6.2.0",
+      "nyc": "^14.1.1",
+      "prettier": "^1.18.2"
+    },
+    "dependencies": {
+      "disparity": "^3.0.0",
+      "package-json-validator": "^0.6.3",
+      "requireindex": "^1.2.0"
+    },
+    "peerDependencies": {
+      "eslint": ">=4.7.0"
+    },
+    "engines": {
+      "node": ">=8.0.0"
+    },
+    "nyc": {
+      "include": [
+        "lib/**"
+      ]
+    }
+  }
+  

--- a/tests/lib/rules/local-dependency.js
+++ b/tests/lib/rules/local-dependency.js
@@ -1,0 +1,299 @@
+/**
+ * @fileoverview Checks existence of local dependencies in the package.json
+ * @author Kendall Gassner
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const path = require('path');
+var rule = require('../../../lib/rules/local-dependency'),
+    RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const fileName = partialPath => {
+    return path.join(process.cwd(), partialPath);
+};
+
+var ruleTester = new RuleTester();
+ruleTester.run('local-dependency', rule, {
+    valid: [
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/local-dependency",
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "peerDependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/local-dependency",
+                        "some-other-package": "some-other-package"
+                    }
+                }`,
+            filename: fileName('package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "devDependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/local-dependency",
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC"
+            }`,
+            filename: fileName('package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                    }
+            }`,
+            filename: fileName('not-package.json')
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-package": "link:../local-dependency"
+                    }
+            }`,
+            filename: fileName(
+                '/tests/lib/__fixtures__/unalphabetized-collections/package.json'
+            )
+        }
+    ],
+    invalid: [
+        {
+            code: `module.exports = {
+                        "name": "pandages",
+                        "version": "1.0.0",
+                        "description": "",
+                        "main": "index.js",
+                        "keywords": [],
+                        "author": "me!",
+                        "license": "ISC",
+                        "dependencies": {
+                            "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                            "some-other-package": "some-other-package"
+                        }
+            }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "peerDependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "devDependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/dependency",
+                        "some-other-package": "some-other-package"
+                    }
+            }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                        "name": "pandages",
+                        "version": "1.0.0",
+                        "description": "",
+                        "main": "index.js",
+                        "keywords": [],
+                        "author": "me!",
+                        "license": "ISC",
+                        "dependencies": {
+                        "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                        "some-other-package": "some-other-package"
+                        },
+                        "peerDependencies": {
+                            "peer-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                            "some-other-package": "some-other-package"
+                        }
+                    }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                },
+                {
+                    message:
+                        'The package peer-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                            "name": "pandages",
+                            "version": "1.0.0",
+                            "description": "",
+                            "main": "index.js",
+                            "keywords": [],
+                            "author": "me!",
+                            "license": "ISC",
+                            "dependencies": {
+                                "some-package": "link:./tests/lib/__fixtures__/Local-dependency",
+                                "another-path": "link:./tests/lib/__fixtures__/local-dependency",
+                                "some-other-package": "some-other-package"
+                            }
+            }`,
+            filename: fileName('package.json'),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:./tests/lib/__fixtures__/Local-dependency.'
+                }
+            ]
+        },
+        {
+            code: `module.exports = {
+                    "name": "pandages",
+                    "version": "1.0.0",
+                    "description": "",
+                    "main": "index.js",
+                    "keywords": [],
+                    "author": "me!",
+                    "license": "ISC",
+                    "dependencies": {
+                        "some-package": "link:../Local-dependency"
+                    }
+            }`,
+            filename: fileName(
+                'tests/lib/__fixtures__/unalphabetized-collections/package.json'
+            ),
+            errors: [
+                {
+                    message:
+                        'The package some-package does not exist given the specified path: link:../Local-dependency.'
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Basically I keep making a mistake where I case am installing a local dependency using "link" and I mess up the casing:

This:
```
  "devDependencies": {
         "some-package": "link:../folder",
   }

```

Should be 
```
  "devDependencies": {
         "some-package": "link:../Folder",
   }

```
Npm doesn't support link but yarn does. When the path is wrong yarn does not sub out the link when releasing.
